### PR TITLE
Add the packaging metadata to build the make8bitart snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: make8bitart
+version: master
+summary: an in-browser canvas tool which is great fun!
+description: |
+  web-based pixel art application that's super fun and easy to use!
+
+grade: devel
+confinement: strict
+
+apps:
+  server:
+    command: sh -c \"cd $SNAP/lib/node_modules/make8bitart && http-server -a localhost -p 8080\"
+    plugs: [network-bind]
+    daemon: simple
+
+parts:
+  make8bitart:
+    source:
+    plugin: nodejs
+    node-packages: [http-server]


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.