### PR TITLE
download art when clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@
         </button>
       </div>
       <h2>you saved your art!</h2>
-      <a href="#" target="_blank"><img id="finished-art" /></a>
+      <a href="#" target="_blank" download="art.png"><img id="finished-art" /></a>
 
       <p>Click or drag your art to your desktop to save!<br />
         <button role="button" class="text-button"id="save-imgur">Or upload to imgur.com!</button>


### PR DESCRIPTION
hi jennnnnn

[Firefox] and [Chrome] have gotten stricter about top-level navigation to `data:` URLs AS YOU NOTED IN ANGER this past Tuesday, so this uses the [`download`][download] attribute to try to get similar behavior without right-clicking.

[Firefox]: https://blog.mozilla.org/security/2017/11/27/blocking-top-level-navigations-data-urls-firefox-58/
[Chrome]: https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/GbVcuwg_QjM%5B1-25%5D
[download]: https://caniuse.com/#feat=download

I tested this by adding it by hand in the Inspector which is very much like actually testing it without being useful at all.