### PR TITLE
Disables autocomplete in the hex input field

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
     <div id="pickers">
       <div id="hex-picker">
         <h2>hex value:</h2>
-        <span class="pound">#</span><input type="text" id="hex-color" value="000000" />
+        <span class="pound">#</span><input type="text" id="hex-color" value="000000" autocomplete="off" autocorrect="off" spellcheck="false" />
 
         <button role="button" id="color-dropper" class="icon-button">
           <img src="assets/dropper.png" alt="color dropper" />


### PR DESCRIPTION
I kept running into the issue that certain hex strings were "autocompleted" into words in Safari on macOS. The way macOS handles this is annoying because it's harder to keep what you actually typed than what its suggested fix is.

<img width="238" alt="screen shot 2018-02-09 at 12 29 12 pm" src="https://user-images.githubusercontent.com/6511018/36041790-acb30002-0d97-11e8-9120-8e2356050b6e.png">